### PR TITLE
RW 2 banks, 1 kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ include $(COMMON_REPO)/libs/opencl/opencl.mk
 
 SRC_DIR=./interface
 
-SRCS=$(SRC_DIR)/double_buffer.cpp $(SRC_DIR)/device_interface.cpp cpu/sha256.cpp cpu/sha_preprocess.cpp main_cpu.cpp cpu/verify.cpp $(SRC_DIR)/defs.hpp
-HDRS=$(SRC_DIR)/device_interface.hpp $(SRC_DIR)/double_buffer.hpp
+SRCS=$(SRC_DIR)/double_buffer.cpp $(SRC_DIR)/device_interface.cpp cpu/sha256.cpp cpu/sha_preprocess.cpp main_cpu.cpp cpu/verify.cpp
+HDRS=$(SRC_DIR)/device_interface.hpp $(SRC_DIR)/double_buffer.hpp $(SRC_DIR)/defs.hpp
 
 
 # Host Application

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ device_kernel_CLFLAGS= -I$(SRC_DIR)/ --max_memory_ports hashing_kernel
 XOS=device_kernel
 
 device_kernel_XOS=device_kernel
-device_kernel_LDCLFLAGS=--xp misc:map_connect=add.kernel.hashing_kernel_1.M_AXI_GMEM0.core.OCL_REGION_0.M00_AXI --xp misc:map_connect=add.kernel.hashing_kernel_1.M_AXI_GMEM1.core.OCL_REGION_0.M01_AXI --xp misc:map_connect=add.kernel.hashing_kernel_1.M_AXI_GMEM2.core.OCL_REGION_0.M02_AXI --xp misc:map_connect=add.kernel.hashing_kernel_1.M_AXI_GMEM3.core.OCL_REGION_0.M03_AXI
+device_kernel_LDCLFLAGS=--xp misc:map_connect=add.kernel.hashing_kernel_1.M_AXI_GMEM0.core.OCL_REGION_0.M00_AXI --xp misc:map_connect=add.kernel.hashing_kernel_1.M_AXI_GMEM1.core.OCL_REGION_0.M01_AXI
 
 XCLBINS=device_kernel
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ include $(COMMON_REPO)/libs/opencl/opencl.mk
 
 SRC_DIR=./interface
 
-SRCS=$(SRC_DIR)/double_buffer.cpp $(SRC_DIR)/device_interface.cpp cpu/sha256.cpp cpu/sha_preprocess.cpp main_cpu.cpp cpu/verify.cpp
+SRCS=$(SRC_DIR)/double_buffer.cpp $(SRC_DIR)/device_interface.cpp cpu/sha256.cpp cpu/sha_preprocess.cpp main_cpu.cpp cpu/verify.cpp $(SRC_DIR)/defs.hpp
 HDRS=$(SRC_DIR)/device_interface.hpp $(SRC_DIR)/double_buffer.hpp
 
 
@@ -23,12 +23,12 @@ EXES=sha256
 # Kernel
 device_kernel_SRCS=$(SRC_DIR)/device_kernel.cl
 
-device_kernel_CLFLAGS= -I$(SRC_DIR)/ --max_memory_ports hashing_kernel0 --max_memory_ports hashing_kernel1
+device_kernel_CLFLAGS= -I$(SRC_DIR)/ --max_memory_ports hashing_kernel
 
 XOS=device_kernel
 
 device_kernel_XOS=device_kernel
-device_kernel_LDCLFLAGS=--xp misc:map_connect=add.kernel.hashing_kernel0_1.M_AXI_GMEM0.core.OCL_REGION_0.M00_AXI --xp misc:map_connect=add.kernel.hashing_kernel0_1.M_AXI_GMEM1.core.OCL_REGION_0.M02_AXI --xp misc:map_connect=add.kernel.hashing_kernel1_1.M_AXI_GMEM0.core.OCL_REGION_0.M01_AXI --xp misc:map_connect=add.kernel.hashing_kernel1_1.M_AXI_GMEM1.core.OCL_REGION_0.M03_AXI
+device_kernel_LDCLFLAGS=--xp misc:map_connect=add.kernel.hashing_kernel_1.M_AXI_GMEM0.core.OCL_REGION_0.M00_AXI --xp misc:map_connect=add.kernel.hashing_kernel_1.M_AXI_GMEM1.core.OCL_REGION_0.M01_AXI --xp misc:map_connect=add.kernel.hashing_kernel_1.M_AXI_GMEM2.core.OCL_REGION_0.M02_AXI --xp misc:map_connect=add.kernel.hashing_kernel_1.M_AXI_GMEM3.core.OCL_REGION_0.M03_AXI
 
 XCLBINS=device_kernel
 

--- a/cpu/sha_preprocess.cpp
+++ b/cpu/sha_preprocess.cpp
@@ -7,6 +7,7 @@ void pre_process(char *element) {
   uint64_t element_length_append;
   element_length_append = str_len*8;
   element[str_len] = 0x80;
+  memset(element+str_len+1, 0, 55-str_len);
 
   element[56] = (element_length_append >> 56) & 0xFF;
   element[57] = (element_length_append >> 48) & 0xFF;

--- a/interface/defs.hpp
+++ b/interface/defs.hpp
@@ -10,7 +10,7 @@
 #define BUFFER_SIZE (CHUNKS_PER_BUFFER * CHUNK_SIZE)
 
 
-const int BUFFER_COUNT = 4;
+const int BUFFER_COUNT = 2;
 
 struct chunk {
   char data[64];
@@ -24,18 +24,5 @@ struct buffer {
 struct global_header {
   int active_buf;
 };
-
-// int modulo1234(int x, int N) {
-//   return (x % N + N) % N;
-// }
-//
-// int PREV(int x) {
-//   return modulo1234(x-1, BUFFER_COUNT);
-// }
-//
-// int NEXT(int x) {
-//   return modulo1234(x+1, BUFFER_COUNT);
-// }
-
 
 #endif

--- a/interface/defs.hpp
+++ b/interface/defs.hpp
@@ -10,7 +10,7 @@
 #define BUFFER_SIZE (CHUNKS_PER_BUFFER * CHUNK_SIZE)
 
 
-const int BUFFER_COUNT = 2;
+const int BUFFER_COUNT = 4;
 
 struct chunk {
   char data[64];
@@ -24,5 +24,18 @@ struct buffer {
 struct global_header {
   int active_buf;
 };
+
+// int modulo1234(int x, int N) {
+//   return (x % N + N) % N;
+// }
+//
+// int PREV(int x) {
+//   return modulo1234(x-1, BUFFER_COUNT);
+// }
+//
+// int NEXT(int x) {
+//   return modulo1234(x+1, BUFFER_COUNT);
+// }
+
 
 #endif

--- a/interface/device_interface.cpp
+++ b/interface/device_interface.cpp
@@ -5,10 +5,6 @@
 #include "defs.hpp"
 #include "xcl2.hpp"
 
-// offset to the read buffer
-#define READ(x) (x+0)
-#define PREV(x) (((x-1) % BUFFER_COUNT + BUFFER_COUNT) % BUFFER_COUNT)
-
 
 void check_error(cl_int err) {
   if (err) {
@@ -41,7 +37,6 @@ DeviceInterface::DeviceInterface() {
   // previous line. A kernel is an OpenCL function that is executed on the
   // FPGA. This function is defined in the interface/device_kernel.cl file.
   krnl_sha = cl::Kernel(program, "hashing_kernel");
-  // krnl_sha[1] = cl::Kernel(program, "hashing_kernel1");
 
   unsigned xcl_banks[4] = {
     XCL_MEM_DDR_BANK0,
@@ -75,18 +70,10 @@ DeviceInterface::DeviceInterface() {
   host_bufs[0] = (struct chunk *) q.enqueueMapBuffer(ocl_bufs[0], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
 }
 
-struct chunk *DeviceInterface::get_write_buffer(int active_buf) {
-  //if (host_bufs[active_buf+2]) {
-  //  q.enqueueUnmapMemObject(ocl_bufs[READ(active_buf)], host_bufs[READ(active_buf)], NULL, NULL);
-  //}
-
-  // CL_MAP_WRITE_INVALIDATE_REGION makes it such that the returned memory
-  // region doesnt have to be up to date. We will just overwrite it so it doesn't matter.
-  //host_bufs[active_buf] = (struct chunk *) q.enqueueMapBuffer(ocl_bufs[active_buf], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
-  // check(err);
+// used to bootstrap
+struct chunk *DeviceInterface::fetch_buffer(int active_buf) {
   return (struct chunk *) host_bufs[active_buf];
 }
-
 
 struct chunk *DeviceInterface::run_fpga(int num_chunks, int active_buf) {
   cl_int err;
@@ -99,8 +86,6 @@ struct chunk *DeviceInterface::run_fpga(int num_chunks, int active_buf) {
   int narg = 0;
   krnl_sha.setArg(narg++, ocl_bufs[0]);
   krnl_sha.setArg(narg++, ocl_bufs[1]);
-  krnl_sha.setArg(narg++, ocl_bufs[2]);
-  krnl_sha.setArg(narg++, ocl_bufs[3]);
   krnl_sha.setArg(narg++, num_chunks);
   krnl_sha.setArg(narg++, active_buf);
 
@@ -108,9 +93,9 @@ struct chunk *DeviceInterface::run_fpga(int num_chunks, int active_buf) {
   q.enqueueTask(krnl_sha);
 
   // previous computations result
-  printf("mapping: %d\n", PREV(active_buf));
-host_bufs[1-active_buf] = (struct chunk *) q.enqueueMapBuffer(ocl_bufs[PREV(active_buf)], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
-  check(err);
+  printf("mapping: %d\n", 1 - active_buf);
+host_bufs[1-active_buf] = (struct chunk *) q.enqueueMapBuffer(ocl_bufs[1 - active_buf], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
+  check_error(err);
   // possibly remove this to allow for multiple kernels to run simultaneously
   q.finish();
 
@@ -119,15 +104,18 @@ host_bufs[1-active_buf] = (struct chunk *) q.enqueueMapBuffer(ocl_bufs[PREV(acti
 
 struct chunk *DeviceInterface::read_last_result(int active_buf) {
   int err;
-  q.enqueueUnmapMemObject(ocl_bufs[READ(active_buf)], host_bufs[READ(active_buf)], NULL, NULL);
+  printf("unmapping: %d\n", active_buf);
+  q.enqueueUnmapMemObject(ocl_bufs[active_buf], host_bufs[active_buf], NULL, NULL);
 
-  host_bufs[READ(1-active_buf)] = q.enqueueMapBuffer(ocl_bufs[READ(1-active_buf)], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
-  check(err);
+  printf("mapping: %d\n", 1 - active_buf);
+  host_bufs[1-active_buf] = q.enqueueMapBuffer(ocl_bufs[1 - active_buf], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
+  check_error(err);
 
-  return (struct chunk *) host_bufs[READ(1-active_buf)];
+  return (struct chunk *) host_bufs[1 - active_buf];
 }
 
 void DeviceInterface::unmap_last_result(int active_buf) {
-  q.enqueueUnmapMemObject(ocl_bufs[READ(1-active_buf)], host_bufs[READ(1-active_buf)]);
+  printf("unmapping: %d\n", 1 - active_buf);
+  q.enqueueUnmapMemObject(ocl_bufs[1-active_buf], host_bufs[1 - active_buf]);
   q.finish();
 }

--- a/interface/device_interface.cpp
+++ b/interface/device_interface.cpp
@@ -100,13 +100,13 @@ struct chunk *DeviceInterface::read_last_result(int active_buf) {
   int err;
   q.enqueueUnmapMemObject(ocl_bufs[active_buf], host_bufs[active_buf], NULL, NULL);
 
-  host_bufs[1-active_buf] = q.enqueueMapBuffer(ocl_bufs[1 - active_buf], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
+  host_bufs[1 - active_buf] = q.enqueueMapBuffer(ocl_bufs[1 - active_buf], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
   check_error(err);
 
   return (struct chunk *) host_bufs[1 - active_buf];
 }
 
 void DeviceInterface::unmap_last_result(int active_buf) {
-  q.enqueueUnmapMemObject(ocl_bufs[1-active_buf], host_bufs[1 - active_buf]);
+  q.enqueueUnmapMemObject(ocl_bufs[1 - active_buf], host_bufs[1 - active_buf]);
   q.finish();
 }

--- a/interface/device_interface.cpp
+++ b/interface/device_interface.cpp
@@ -66,7 +66,6 @@ DeviceInterface::DeviceInterface() {
     host_bufs[i] = nullptr;
   }
 
-  puts("host bufs 0");
   host_bufs[0] = (struct chunk *) q.enqueueMapBuffer(ocl_bufs[0], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
 }
 
@@ -77,8 +76,6 @@ struct chunk *DeviceInterface::fetch_buffer(int active_buf) {
 
 struct chunk *DeviceInterface::run_fpga(int num_chunks, int active_buf) {
   cl_int err;
-  // unmap input buffer
-  printf("unmapping: %d\n", active_buf);
   q.enqueueUnmapMemObject(ocl_bufs[active_buf], host_bufs[active_buf], NULL, NULL);
   q.finish();
 
@@ -93,21 +90,18 @@ struct chunk *DeviceInterface::run_fpga(int num_chunks, int active_buf) {
   q.enqueueTask(krnl_sha);
 
   // previous computations result
-  printf("mapping: %d\n", 1 - active_buf);
-host_bufs[1-active_buf] = (struct chunk *) q.enqueueMapBuffer(ocl_bufs[1 - active_buf], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
+host_bufs[1 - active_buf] = (struct chunk *) q.enqueueMapBuffer(ocl_bufs[1 - active_buf], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
   check_error(err);
   // possibly remove this to allow for multiple kernels to run simultaneously
   q.finish();
 
-  return (struct chunk *) host_bufs[1-active_buf];
+  return (struct chunk *) host_bufs[1 - active_buf];
 }
 
 struct chunk *DeviceInterface::read_last_result(int active_buf) {
   int err;
-  printf("unmapping: %d\n", active_buf);
   q.enqueueUnmapMemObject(ocl_bufs[active_buf], host_bufs[active_buf], NULL, NULL);
 
-  printf("mapping: %d\n", 1 - active_buf);
   host_bufs[1-active_buf] = q.enqueueMapBuffer(ocl_bufs[1 - active_buf], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
   check_error(err);
 
@@ -115,7 +109,6 @@ struct chunk *DeviceInterface::read_last_result(int active_buf) {
 }
 
 void DeviceInterface::unmap_last_result(int active_buf) {
-  printf("unmapping: %d\n", 1 - active_buf);
   q.enqueueUnmapMemObject(ocl_bufs[1-active_buf], host_bufs[1 - active_buf]);
   q.finish();
 }

--- a/interface/device_interface.cpp
+++ b/interface/device_interface.cpp
@@ -90,10 +90,8 @@ struct chunk *DeviceInterface::run_fpga(int num_chunks, int active_buf) {
   q.enqueueTask(krnl_sha);
 
   // previous computations result
-host_bufs[1 - active_buf] = (struct chunk *) q.enqueueMapBuffer(ocl_bufs[1 - active_buf], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
+  host_bufs[1 - active_buf] = (struct chunk *) q.enqueueMapBuffer(ocl_bufs[1 - active_buf], CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFFER_SIZE, NULL, NULL, &err);
   check_error(err);
-  // possibly remove this to allow for multiple kernels to run simultaneously
-  q.finish();
 
   return (struct chunk *) host_bufs[1 - active_buf];
 }

--- a/interface/device_interface.hpp
+++ b/interface/device_interface.hpp
@@ -19,7 +19,7 @@ class DeviceInterface {
  private:
   cl::CommandQueue q;
   cl::Program program;
-  cl::Kernel krnl_sha[2];
+  cl::Kernel krnl_sha;
 
   cl::Buffer ocl_bufs[BUFFER_COUNT*2];
   void *host_bufs[BUFFER_COUNT*2];

--- a/interface/device_interface.hpp
+++ b/interface/device_interface.hpp
@@ -9,10 +9,9 @@
 class DeviceInterface {
  public:
   DeviceInterface();
-  // result written directly to buf
-  struct chunk *get_write_buffer(int active_buf);
   struct chunk *run_fpga(int num_chunks, int active_buf);
   struct chunk *read_last_result(int active_buf);
+  struct chunk *fetch_buffer(int active_buf);
   void unmap_last_result(int active_buf);
   ~DeviceInterface() = default;
 
@@ -21,9 +20,9 @@ class DeviceInterface {
   cl::Program program;
   cl::Kernel krnl_sha;
 
-  cl::Buffer ocl_bufs[BUFFER_COUNT*2];
-  void *host_bufs[BUFFER_COUNT*2];
-  cl_mem_ext_ptr_t buffer_ext[BUFFER_COUNT*2];  // Declaring two extensions for both buffers
+  cl::Buffer ocl_bufs[BUFFER_COUNT];
+  void *host_bufs[BUFFER_COUNT];
+  cl_mem_ext_ptr_t buffer_ext[BUFFER_COUNT];
 };
 
 #endif

--- a/interface/device_kernel.cl
+++ b/interface/device_kernel.cl
@@ -11,21 +11,15 @@ struct chunk{
 kernel __attribute__((reqd_work_group_size(1, 1, 1)))
 void hashing_kernel(__global struct chunk * __restrict buffer0,
 		    __global struct chunk * __restrict buffer1,
-		    __global struct chunk * __restrict buffer2,
-		    __global struct chunk * __restrict buffer3,
 		    const int n_elements,
 		    const int active_buf) {
-  printf("HELLO FROM FPGA KERNEL 0\n");
+  printf("HELLO FROM FPGA KERNEL\n");
 
   __global struct chunk *buffer;
   if (active_buf == 0) {
     buffer = buffer0;
   } else if (active_buf == 1) {
     buffer = buffer1;
-  } else if (active_buf == 2) {
-    buffer = buffer2;
-  } else if (active_buf == 3) {
-    buffer = buffer3;
   }
 
   //__attribute__((opencl_unroll_hint(n)))

--- a/interface/device_kernel.cl
+++ b/interface/device_kernel.cl
@@ -2,12 +2,111 @@
 #define NUMBER_ONE 1
 #define DATA_TO_TOUCH 32
 
+#define ROTR(x, n) (((x) >> (n)) | ((x) << ((32) - (n)))) //from https://stackoverflow.com/questions/21895604/rotate-right-by-n-only-using-bitwise-operators-in-c
+
+// https://www.xilinx.com/html_docs/xilinx2017_2/sdaccel_doc/topics/pragmas/concept-Intro_to_OpenCL_attributes.html
 
 struct chunk{
   char data[DATA_SIZE];
 };
 
-// https://www.xilinx.com/html_docs/xilinx2017_2/sdaccel_doc/topics/pragmas/concept-Intro_to_OpenCL_attributes.html
+
+//auxiliary functions for the hashing algorithm
+uint ch(uint x, uint y, uint z) {
+  return (x & y)^(~x & z);
+}
+
+uint maj(uint x, uint y, uint z) {
+  return (x & y)^(x & z)^(y & z);
+}
+
+uint sigma0(uint x) {
+  return (ROTR(x, 7))^(ROTR(x, 18))^(x >> 3);
+}
+
+uint sigma1(uint x) {
+  return (ROTR(x, 17))^(ROTR(x, 19))^(x >> 10);
+}
+
+uint zigma0(uint x) {
+  return (ROTR(x, 2))^(ROTR(x, 13))^(ROTR(x, 22));
+}
+
+uint zigma1(uint x) {
+  return (ROTR(x, 6))^(ROTR(x, 11))^(ROTR(x, 25));
+}
+
+void sha256(__global char *buffer) {
+
+  __private uint K[64] = {
+    0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+    0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+    0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+    0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+    0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+    0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+    0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+    0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+  };
+
+
+  //Prepare Message Schedule
+  uint H0[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+  uint W[64];
+  uint a,b,c,d,e,f,g,h,t1,t2;
+  int j = 0;
+  //  __attribute__((opencl_unroll_hint(n)))
+  for (int i = 0;  i < 16; i++) {
+    W[i] = ((__global unsigned char) buffer[j] << 24) | ((__global unsigned char) buffer[j+1] << 16) | ((__global unsigned char) buffer[j+2] << 8) | ((__global unsigned char) buffer[j+3]);
+    j += 4;
+  }
+
+  //__attribute__((opencl_unroll_hint(n)))
+  for (int i = 16; i < 64; i++) {
+    W[i] = sigma1(W[i-2]) + W[i-7] + sigma0(W[i-15]) + W[i-16];
+  }
+
+  //Initialize working variables
+  a = H0[0];
+  b = H0[1];
+  c = H0[2];
+  d = H0[3];
+  e = H0[4];
+  f = H0[5];
+  g = H0[6];
+  h = H0[7];
+
+  //Compute Hash
+  for (int i = 0; i < 64; i++) {
+    t1 = h + zigma1(e) + ch(e, f, g) + K[i] + W[i];
+    t2 = zigma0(a) + maj(a, b, c);
+    h = g;
+    g = f;
+    f = e;
+    e = d + t1;
+    d = c;
+    c = b;
+    b = a;
+    a = t1 + t2;
+  }
+
+  H0[0] = H0[0] + a;
+  H0[1] = H0[1] + b;
+  H0[2] = H0[2] + c;
+  H0[3] = H0[3] + d;
+  H0[4] = H0[4] + e;
+  H0[5] = H0[5] + f;
+  H0[6] = H0[6] + g;
+  H0[7] = H0[7] + h;
+
+  //Store hash in buffer
+  //__attribute__((opencl_unroll_hint(n)))
+  for (int i = 0; i < 8; i++) {
+    ((__global uint *) buffer)[i] = (((unsigned char *) H0)[i*4] << 24) | (((unsigned char *) H0)[i*4+1] << 16) | (((unsigned char *) H0)[i*4+2] << 8) | (((unsigned char *) H0)[i*4+3]);
+  }
+}
+
+
 kernel __attribute__((reqd_work_group_size(1, 1, 1)))
 void hashing_kernel(__global struct chunk * __restrict buffer0,
 		    __global struct chunk * __restrict buffer1,
@@ -22,13 +121,8 @@ void hashing_kernel(__global struct chunk * __restrict buffer0,
     buffer = buffer1;
   }
 
-  //__attribute__((opencl_unroll_hint(n)))
-  __attribute__((xcl_pipeline_loop))
-    for (int i = 0; i < n_elements; i++) {
-      // __attribute__((xcl_pipeline_loop))
-      for (int j = 0; j < 16; j++) {
-	buffer[i].data[j] = buffer[i].data[j] + NUMBER_ONE;
-      }
-      //sha2560(input_buffer[i].data, output_buffer[i].data);
-    }
+  // __attribute__((xcl_pipeline_loop))
+  for (int i = 0; i < n_elements; i++) {
+    sha256(buffer[i].data);
+  }
 }

--- a/interface/device_kernel.cl
+++ b/interface/device_kernel.cl
@@ -2,203 +2,39 @@
 #define NUMBER_ONE 1
 #define DATA_TO_TOUCH 32
 
-#define ROTR(x, n) (((x) >> (n)) | ((x) << ((32) - (n)))) //from https://stackoverflow.com/questions/21895604/rotate-right-by-n-only-using-bitwise-operators-in-c
 
 struct chunk{
   char data[DATA_SIZE];
 };
 
-
-//auxiliary functions for the hashing algorithm
-uint ch(uint x, uint y, uint z) {
-  return (x & y)^(~x & z);
-}
-
-uint maj(uint x, uint y, uint z) {
-  return (x & y)^(x & z)^(y & z);
-}
-
-uint sigma0(uint x) {
-  return (ROTR(x, 7))^(ROTR(x, 18))^(x >> 3);
-}
-
-uint sigma1(uint x) {
-  return (ROTR(x, 17))^(ROTR(x, 19))^(x >> 10);
-}
-
-uint zigma0(uint x) {
-  return (ROTR(x, 2))^(ROTR(x, 13))^(ROTR(x, 22));
-}
-
-uint zigma1(uint x) {
-  return (ROTR(x, 6))^(ROTR(x, 11))^(ROTR(x, 25));
-}
-
-void sha2560(__global char *input_address, __global char *output_address) {
-
-  __private uint K[64] = {
-  0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
-  0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
-  0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
-  0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
-  0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
-  0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
-  0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
-  0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
-};
-
-
-  //Prepare Message Schedule
-  uint H0[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
-  uint W[64];
-  uint a,b,c,d,e,f,g,h,t1,t2;
-  int j = 0;
-  //  __attribute__((opencl_unroll_hint(n)))
-  for (int i = 0;  i < 16; i++) {
-    W[i] = ((__global unsigned char) input_address[j] << 24) | ((__global unsigned char) input_address[j+1] << 16) | ((__global unsigned char) input_address[j+2] << 8) | ((__global unsigned char) input_address[j+3]);
-    j += 4;
-  }
-
-  //__attribute__((opencl_unroll_hint(n)))
-  for (int i = 16; i < 64; i++) {
-    W[i] = sigma1(W[i-2]) + W[i-7] + sigma0(W[i-15]) + W[i-16];
-  }
-
-  //Initialize working variables
-  a = H0[0];
-  b = H0[1];
-  c = H0[2];
-  d = H0[3];
-  e = H0[4];
-  f = H0[5];
-  g = H0[6];
-  h = H0[7];
-
-  //Compute Hash
-  for (int i = 0; i < 64; i++) {
-    t1 = h + zigma1(e) + ch(e, f, g) + K[i] + W[i];
-    t2 = zigma0(a) + maj(a, b, c);
-    h = g;
-    g = f;
-    f = e;
-    e = d + t1;
-    d = c;
-    c = b;
-    b = a;
-    a = t1 + t2;
-  }
-
-  H0[0] = H0[0] + a;
-  H0[1] = H0[1] + b;
-  H0[2] = H0[2] + c;
-  H0[3] = H0[3] + d;
-  H0[4] = H0[4] + e;
-  H0[5] = H0[5] + f;
-  H0[6] = H0[6] + g;
-  H0[7] = H0[7] + h;
-
-  //Store hash in input buffer
-  //__attribute__((opencl_unroll_hint(n)))
-  for (int i = 0; i < 8; i++) {
-    ((__global uint *) output_address)[i] = (((unsigned char *) H0)[i*4] << 24) | (((unsigned char *) H0)[i*4+1] << 16) | (((unsigned char *) H0)[i*4+2] << 8) | (((unsigned char *) H0)[i*4+3]);
-  }
-}
-
-void sha2561(__global char *input_address, __global char *output_address) {
-
-  __private uint K[64] = {
-  0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
-  0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
-  0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
-  0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
-  0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
-  0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
-  0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
-  0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
-};
-
-
-  //Prepare Message Schedule
-  uint H0[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
-  uint W[64];
-  uint a,b,c,d,e,f,g,h,t1,t2;
-  int j = 0;
-  //  __attribute__((opencl_unroll_hint(n)))
-  for (int i = 0;  i < 16; i++) {
-    W[i] = ((__global unsigned char) input_address[j] << 24) | ((__global unsigned char) input_address[j+1] << 16) | ((__global unsigned char) input_address[j+2] << 8) | ((__global unsigned char) input_address[j+3]);
-    j += 4;
-  }
-
-  //__attribute__((opencl_unroll_hint(n)))
-  for (int i = 16; i < 64; i++) {
-    W[i] = sigma1(W[i-2]) + W[i-7] + sigma0(W[i-15]) + W[i-16];
-  }
-
-  //Initialize working variables
-  a = H0[0];
-  b = H0[1];
-  c = H0[2];
-  d = H0[3];
-  e = H0[4];
-  f = H0[5];
-  g = H0[6];
-  h = H0[7];
-
-  //Compute Hash
-  for (int i = 0; i < 64; i++) {
-    t1 = h + zigma1(e) + ch(e, f, g) + K[i] + W[i];
-    t2 = zigma0(a) + maj(a, b, c);
-    h = g;
-    g = f;
-    f = e;
-    e = d + t1;
-    d = c;
-    c = b;
-    b = a;
-    a = t1 + t2;
-  }
-
-  H0[0] = H0[0] + a;
-  H0[1] = H0[1] + b;
-  H0[2] = H0[2] + c;
-  H0[3] = H0[3] + d;
-  H0[4] = H0[4] + e;
-  H0[5] = H0[5] + f;
-  H0[6] = H0[6] + g;
-  H0[7] = H0[7] + h;
-
-  //Store hash in input buffer
-  //__attribute__((opencl_unroll_hint(n)))
-  for (int i = 0; i < 8; i++) {
-    ((__global uint *) output_address)[i] = (((unsigned char *) H0)[i*4] << 24) | (((unsigned char *) H0)[i*4+1] << 16) | (((unsigned char *) H0)[i*4+2] << 8) | (((unsigned char *) H0)[i*4+3]);
-  }
-}
-
-
 // https://www.xilinx.com/html_docs/xilinx2017_2/sdaccel_doc/topics/pragmas/concept-Intro_to_OpenCL_attributes.html
 kernel __attribute__((reqd_work_group_size(1, 1, 1)))
-void hashing_kernel0(__global struct chunk * __restrict input_buffer,
-		     __global struct chunk * __restrict output_buffer,
-		     const int n_elements) {
+void hashing_kernel(__global struct chunk * __restrict buffer0,
+		    __global struct chunk * __restrict buffer1,
+		    __global struct chunk * __restrict buffer2,
+		    __global struct chunk * __restrict buffer3,
+		    const int n_elements,
+		    const int active_buf) {
   printf("HELLO FROM FPGA KERNEL 0\n");
+
+  __global struct chunk *buffer;
+  if (active_buf == 0) {
+    buffer = buffer0;
+  } else if (active_buf == 1) {
+    buffer = buffer1;
+  } else if (active_buf == 2) {
+    buffer = buffer2;
+  } else if (active_buf == 3) {
+    buffer = buffer3;
+  }
+
   //__attribute__((opencl_unroll_hint(n)))
   __attribute__((xcl_pipeline_loop))
     for (int i = 0; i < n_elements; i++) {
       // __attribute__((xcl_pipeline_loop))
-      sha2560(input_buffer[i].data, output_buffer[i].data);
-    }
-}
-
-
-kernel __attribute__((reqd_work_group_size(1, 1, 1)))
-void hashing_kernel1(__global struct chunk * __restrict input_buffer,
-		     __global struct chunk * __restrict output_buffer,
-		     const int n_elements) {
-  printf("HELLO FROM FPGA KERNEL 1\n");
-  //__attribute__((opencl_unroll_hint(n)))
-  __attribute__((xcl_pipeline_loop))
-    for (int i = 0; i < n_elements; i++) {
-      // __attribute__((xcl_pipeline_loop))
-      sha2561(input_buffer[i].data, output_buffer[i].data);
+      for (int j = 0; j < 16; j++) {
+	buffer[i].data[j] = buffer[i].data[j] + NUMBER_ONE;
+      }
+      //sha2560(input_buffer[i].data, output_buffer[i].data);
     }
 }

--- a/interface/double_buffer.cpp
+++ b/interface/double_buffer.cpp
@@ -25,14 +25,15 @@
    8. CPU calls get_result and receives result from interface.
    9. goto 1.
  */
+#define NEXT(x) (((x+1) % BUFFER_COUNT + BUFFER_COUNT) % BUFFER_COUNT)
 
 DoubleBuffer::DoubleBuffer() {
   glob_head.active_buf = 0;
-  bufs[0].num_chunks = 0;
-  bufs[1].num_chunks = 0;
+  for (int i = 0; i < BUFFER_COUNT; i++) {
+    bufs[i].num_chunks = 0;
+  }
 
   dev_if = new DeviceInterface();
-
   flip_flag = 1;
 }
 
@@ -56,9 +57,9 @@ struct chunk *DoubleBuffer::get_chunk() {
 
 struct buffer DoubleBuffer::start_processing() {
   // run kernel
-  bufs[1 - glob_head.active_buf].chunks = dev_if->run_fpga(bufs[glob_head.active_buf].num_chunks, glob_head.active_buf);
+  bufs[NEXT(glob_head.active_buf)].chunks = dev_if->run_fpga(bufs[glob_head.active_buf].num_chunks, glob_head.active_buf);
   // flip buffers
-  glob_head.active_buf = 1 - glob_head.active_buf;
+  glob_head.active_buf = NEXT(glob_head.active_buf);
   flip_flag = 1;
   // result is in our new active buffer, which is also where we write new data.
   chunk_to_write = bufs[glob_head.active_buf].chunks;

--- a/interface/double_buffer.cpp
+++ b/interface/double_buffer.cpp
@@ -68,8 +68,8 @@ struct buffer DoubleBuffer::start_processing() {
 }
 
 struct buffer DoubleBuffer::get_last_result() {
-  bufs[glob_head.active_buf].chunks = dev_if->read_last_result(glob_head.active_buf);
-  return bufs[glob_head.active_buf];
+  bufs[1 - glob_head.active_buf].chunks = dev_if->read_last_result(glob_head.active_buf);
+  return bufs[1 - glob_head.active_buf];
 }
 
 DoubleBuffer::~DoubleBuffer() {

--- a/interface/double_buffer.cpp
+++ b/interface/double_buffer.cpp
@@ -72,6 +72,11 @@ struct buffer DoubleBuffer::get_last_result() {
   return bufs[1 - glob_head.active_buf];
 }
 
+void DoubleBuffer::regret_get_chunk() {
+  bufs[glob_head.active_buf].num_chunks--;
+  chunk_to_write -= 1;
+}
+
 DoubleBuffer::~DoubleBuffer() {
   dev_if->unmap_last_result(glob_head.active_buf);
   delete dev_if;

--- a/interface/double_buffer.hpp
+++ b/interface/double_buffer.hpp
@@ -10,6 +10,7 @@
 class DoubleBuffer {
  public:
   struct chunk *get_chunk();
+  void regret_get_chunk();
   struct buffer start_processing();
   struct buffer get_last_result();
   DoubleBuffer();

--- a/main_cpu.cpp
+++ b/main_cpu.cpp
@@ -84,7 +84,7 @@ void sha256_fpga(std::string filename,int lines_to_read,int dopt) {
 int main(int argc, char ** argv) {
   /*Initialization*/
   int c, svalue, filesize, lines_to_read = -1;
-  int bopt = 0, dopt = 0, sopt = 0, fopt = 0, vopt = 0;
+  int bopt = 0, dopt = 1, sopt = 0, fopt = 0, vopt = 0;
   char *fvalue = NULL;
   std::string filename;
   std::chrono::duration<double> time_total;

--- a/main_cpu.cpp
+++ b/main_cpu.cpp
@@ -65,7 +65,6 @@ void sha256_fpga(std::string filename,int lines_to_read,int dopt) {
       break;
     }
   }
-  result = double_buffer->start_processing();
   result = double_buffer->get_last_result();
 
   if (dopt == 1) {

--- a/main_cpu.cpp
+++ b/main_cpu.cpp
@@ -17,63 +17,59 @@
 #include "cpu/verify.hpp"
 
 
+void print_result(struct buffer result) {
+  for (int i = 0; i < result.num_chunks; i++) {
+    for (int j = 0; j < 32; j++) {
+      printf("%02x", ((unsigned char *)result.chunks[i].data)[j]);
+    }
+    printf("\n");
+  }
+}
+
 void sha256_fpga(std::string filename,int lines_to_read,int dopt) {
   DoubleBuffer *double_buffer;
   char *chunk_placement_ptr;
-  char element[64];
   struct buffer result;
 
   double_buffer = new DoubleBuffer();
   std::fstream file;
   file.open(filename);
 
-  while (!file.eof()) {
-    memset(element,0,64);
-    file >> element;
-    chunk_placement_ptr = double_buffer->get_chunk()->data;
-   //change element to directly char *data
-    if (dopt == 1) {
-      std::cout << "reading string: " << element << std::endl;
+  while (1) {
+    // if we want to keep going
+    if (!file.eof() && lines_to_read != 0) {
+      chunk_placement_ptr = double_buffer->get_chunk()->data;
     }
-
-    if (chunk_placement_ptr == nullptr) {
-      if (dopt == 1) {
+    // launch fpga
+    if (chunk_placement_ptr == nullptr || file.eof() || lines_to_read == 0) {
+      if (dopt) {
         std::cout << "get_chunk() returned nullptr" << std::endl;
         std::cout << "running start_processing().." << std::endl;
       }
       result = double_buffer->start_processing();
-      if (dopt == 1) {
-        for (int i=0;i<result.num_chunks;i++) {
-	  for (int j = 0; j < 32; j++) {
-	    printf("%02x", ((unsigned char *)result.chunks[i].data)[j]);
-	  }
-	  printf("\n");
-        }
+      if (dopt) {
+	print_result(result);
       }
 
-      chunk_placement_ptr = double_buffer->get_chunk()->data;
-    }
-      if (dopt == 1) {
-  	std::cout << "get_chunk() returned value " << std::endl;
+      if (file.eof() || lines_to_read == 0) {
+	break;
       }
-    /* should always run this part */
-    pre_process(element);
-    memcpy(chunk_placement_ptr,element,sizeof(element));
-    lines_to_read--;
+    } else {
+      memset(chunk_placement_ptr, 0, 64);
+      file >> chunk_placement_ptr;
+      if (dopt) {
+	std::cout << "get_chunk() returned ptr" << std::endl;
+	std::cout << "reading string from file: " << chunk_placement_ptr << std::endl;
+      }
 
-    if (lines_to_read == 0) {
-      break;
+      pre_process(chunk_placement_ptr);
+      lines_to_read--;
     }
   }
-  result = double_buffer->get_last_result();
 
-  if (dopt == 1) {
-    for (int i=0;i<result.num_chunks;i++) {
-      for (int j = 0; j < 32; j++) {
-        printf("%02x", ((unsigned char *)result.chunks[i].data)[j]);
-      }
-      printf("\n");
-    }
+  result = double_buffer->get_last_result();
+  if (dopt) {
+    print_result(result);
   }
 
   file.close();
@@ -83,7 +79,7 @@ void sha256_fpga(std::string filename,int lines_to_read,int dopt) {
 int main(int argc, char ** argv) {
   /*Initialization*/
   int c, svalue, filesize, lines_to_read = -1;
-  int bopt = 0, dopt = 1, sopt = 0, fopt = 0, vopt = 0;
+  int bopt = 0, dopt = 0, sopt = 0, fopt = 0, vopt = 0;
   char *fvalue = NULL;
   std::string filename;
   std::chrono::duration<double> time_total;
@@ -132,19 +128,19 @@ int main(int argc, char ** argv) {
   }
 
   std::cout << "======================== PRE SETTINGS ==========================" << std::endl;
-  if (vopt == 1) {
+  if (vopt) {
     std::cout << "verification mode is on" << std::endl;
   }
 
-  if (dopt == 1) {
+  if (dopt) {
     std::cout << "debug mode is on" << std::endl;
   }
 
-  if (bopt == 1) {
+  if (bopt) {
     std::cout << "benchmark mode is on" << std::endl;
   }
 
-  if (fopt == 1) { //filename flag
+  if (fopt) { //filename flag
     filename = fvalue;
     std::cout << "filename: " << filename << std::endl;
   } else {
@@ -152,7 +148,7 @@ int main(int argc, char ** argv) {
     std::cout << "filename: " << filename << std::endl;
   }
 
-  if (sopt == 1) { //size flag
+  if (sopt) { //size flag
     filesize = svalue * 1000;
     lines_to_read = trunc(filesize/64);
     std::cout << "size: " << filesize << "MB" << std::endl;
@@ -169,7 +165,7 @@ int main(int argc, char ** argv) {
   auto end = std::chrono::system_clock::now();
   time_total = end - start;
 
-  if (bopt == 1) {
+  if (bopt) {
     std::cout << "Running sha256 CPU program..." << std::endl;
     auto start = std::chrono::system_clock::now();
     //benchmark program specified for hardware
@@ -183,7 +179,7 @@ int main(int argc, char ** argv) {
     std::cout << "================================================================" << std::endl;
   }
 
-  if (vopt == 1) {
+  if (vopt) {
     std::cout << "====================== VERIFICATION RESULTS =======================" << std::endl;
     verify(filename);
     std::cout << "================================================================" << std::endl;

--- a/main_cpu.cpp
+++ b/main_cpu.cpp
@@ -61,7 +61,6 @@ void sha256_fpga(std::string filename,int lines_to_read,int dopt) {
 	std::cout << "get_chunk() returned ptr" << std::endl;
 	std::cout << "reading string from file: " << chunk_placement_ptr << std::endl;
       }
-
       pre_process(chunk_placement_ptr);
       lines_to_read--;
     }
@@ -78,8 +77,9 @@ void sha256_fpga(std::string filename,int lines_to_read,int dopt) {
 
 int main(int argc, char ** argv) {
   /*Initialization*/
-  int c, svalue, filesize, lines_to_read = -1;
+  int c, filesize, lines_to_read = -1;
   int bopt = 0, dopt = 0, sopt = 0, fopt = 0, vopt = 0;
+  double svalue;
   char *fvalue = NULL;
   std::string filename;
   std::chrono::duration<double> time_total;
@@ -106,7 +106,7 @@ int main(int argc, char ** argv) {
     }
     case 's': {
       sopt = 1;
-      svalue = std::stoi(optarg);
+      svalue = std::stod(optarg);
       break;
     }
     case 'h': {
@@ -149,9 +149,9 @@ int main(int argc, char ** argv) {
   }
 
   if (sopt) { //size flag
-    filesize = svalue * 1000;
+    filesize = svalue * 1000 * 1000;
     lines_to_read = trunc(filesize/64);
-    std::cout << "size: " << filesize << "MB" << std::endl;
+    std::cout << "size: " << svalue << "MB" << std::endl;
     std::cout << "lines_to_read: " << lines_to_read << std::endl;
   } else {
     std::cout << "size: whole file will be read" << std::endl;

--- a/main_cpu.cpp
+++ b/main_cpu.cpp
@@ -29,6 +29,7 @@ void print_result(struct buffer result) {
 void sha256_fpga(std::string filename, int lines_to_read, int dopt) {
   DoubleBuffer *double_buffer;
   char *chunk_placement_ptr;
+  int written_chunks = 0;
   struct buffer result;
 
   double_buffer = new DoubleBuffer();
@@ -47,6 +48,7 @@ void sha256_fpga(std::string filename, int lines_to_read, int dopt) {
         std::cout << "running start_processing().." << std::endl;
       }
       result = double_buffer->start_processing();
+      written_chunks = 0;
       if (dopt) {
 	print_result(result);
       }
@@ -55,8 +57,19 @@ void sha256_fpga(std::string filename, int lines_to_read, int dopt) {
 	break;
       }
     } else {
-      memset(chunk_placement_ptr, 0, 64);
       file >> chunk_placement_ptr;
+
+      // last read is eof and garbage
+      // either process written chunks or exit
+      if (file.eof()) {
+	double_buffer->regret_get_chunk();
+	if (written_chunks) {
+	  continue;
+	} else {
+	  break;
+	}
+      }
+      written_chunks++;
       if (dopt) {
 	std::cout << "get_chunk() returned ptr" << std::endl;
 	std::cout << "reading string from file: " << chunk_placement_ptr << std::endl;

--- a/main_cpu.cpp
+++ b/main_cpu.cpp
@@ -26,7 +26,7 @@ void print_result(struct buffer result) {
   }
 }
 
-void sha256_fpga(std::string filename,int lines_to_read,int dopt) {
+void sha256_fpga(std::string filename, int lines_to_read, int dopt) {
   DoubleBuffer *double_buffer;
   char *chunk_placement_ptr;
   struct buffer result;


### PR DESCRIPTION
The system now utilizes 2 banks, one for each buffer in the double buffer. The kernel can also switch between the buffers, so we only have one kernel now. 

cpu_main is also modified such that it behaves correctly for all file sizes. 

The `-s` flag now also works correctly.